### PR TITLE
removing getMarketInfoCache

### DIFF
--- a/api.json
+++ b/api.json
@@ -346,7 +346,7 @@
           "event"
         ], 
         "method": "getBondPoster", 
-        "returns": "address", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -446,7 +446,7 @@
           "event"
         ], 
         "method": "getOriginalVotePeriod", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -503,8 +503,7 @@
           "bondPoster"
         ], 
         "method": "setBondPoster", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -525,8 +524,7 @@
           "event"
         ], 
         "method": "setFinal", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -581,8 +579,7 @@
           "ethicality"
         ], 
         "method": "setOriginalEthicality", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -594,8 +591,7 @@
           "originalOutcome"
         ], 
         "method": "setOriginalOutcome", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -607,8 +603,7 @@
           "period"
         ], 
         "method": "setOriginalVotePeriod", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -634,8 +629,7 @@
           "roundTwo"
         ], 
         "method": "setRoundTwo", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -682,14 +676,14 @@
           "branchNumber"
         ], 
         "method": "getBranchByNum", 
-        "returns": "hash", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
       }, 
       "getBranches": {
         "method": "getBranches", 
-        "returns": "hash[]"
+        "returns": "int256[]"
       }, 
       "getCreationDate": {
         "inputs": [
@@ -738,7 +732,7 @@
           "branch"
         ], 
         "method": "getMarketsInBranch", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -748,21 +742,21 @@
           "branch"
         ], 
         "method": "getMinTradingFee", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
       }, 
       "getNumBranches": {
         "method": "getNumBranches", 
-        "returns": "number"
+        "returns": "int256"
       }, 
       "getNumMarketsBranch": {
         "inputs": [
           "branch"
         ], 
         "method": "getNumMarketsBranch", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -802,7 +796,7 @@
           "branch"
         ], 
         "method": "getPeriodLength", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -826,7 +820,7 @@
           "branch"
         ], 
         "method": "getVotePeriod", 
-        "returns": "int", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -836,16 +830,14 @@
           "branch"
         ], 
         "method": "incrementPeriod", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
       }, 
       "initDefaultBranch": {
         "method": "initDefaultBranch", 
-        "returns": "number", 
-        "send": true
+        "returns": "int256"
       }, 
       "initializeBranch": {
         "inputs": [
@@ -927,8 +919,7 @@
           "outcome"
         ], 
         "method": "buy", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -941,8 +932,7 @@
           "trade_id"
         ], 
         "method": "cancel", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -955,8 +945,7 @@
           "outcome"
         ], 
         "method": "sell", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -972,8 +961,7 @@
           "amount"
         ], 
         "method": "addCash", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -984,23 +972,21 @@
           "address"
         ], 
         "method": "balance", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
       }, 
       "depositEther": {
         "method": "depositEther", 
-        "returns": "number", 
-        "send": true
+        "returns": "int256"
       }, 
       "initiateOwner": {
         "inputs": [
           "account"
         ], 
         "method": "initiateOwner", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -1011,8 +997,7 @@
           "value"
         ], 
         "method": "send", 
-        "returns": "unfix", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1025,8 +1010,7 @@
           "from"
         ], 
         "method": "sendFrom", 
-        "returns": "unfix", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -1039,8 +1023,7 @@
           "balance"
         ], 
         "method": "setCash", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1064,8 +1047,7 @@
           "value"
         ], 
         "method": "withdrawEther", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1079,8 +1061,7 @@
           "market"
         ], 
         "method": "claimProceeds", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1093,8 +1074,7 @@
           "sender"
         ], 
         "method": "closeMarket", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -1147,8 +1127,7 @@
           "sender"
         ], 
         "method": "collectFees", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1162,8 +1141,7 @@
           "amount"
         ], 
         "method": "buyCompleteSets", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1175,8 +1153,7 @@
           "amount"
         ], 
         "method": "sellCompleteSets", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1189,7 +1166,7 @@
           "marketIDs"
         ], 
         "method": "batchGetMarketInfo", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256[]"
         ]
@@ -1199,17 +1176,7 @@
           "marketID"
         ], 
         "method": "getMarketInfo", 
-        "returns": "hash[]", 
-        "signature": [
-          "int256"
-        ]
-      }, 
-      "getMarketInfoCache": {
-        "inputs": [
-          "marketID"
-        ], 
-        "method": "getMarketInfoCache", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -1221,7 +1188,7 @@
           "numMarketsToLoad"
         ], 
         "method": "getMarketsInfo", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256", 
           "int256", 
@@ -1233,7 +1200,7 @@
           "marketID"
         ], 
         "method": "getOrderBook", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -1245,8 +1212,7 @@
           "branch"
         ], 
         "method": "incrementPeriodAfterReporting", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -1257,9 +1223,6 @@
           "event"
         ], 
         "method": "penalizeWrong", 
-        "mutable": true, 
-        "returns": "number", 
-        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1320,7 +1283,7 @@
           "period"
         ], 
         "method": "getFeesCollected", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -1377,7 +1340,7 @@
           "sender"
         ], 
         "method": "getPenalizedUpTo", 
-        "returns": "int", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1401,7 +1364,7 @@
           "reporter"
         ], 
         "method": "getRepRedistributionDone", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1585,8 +1548,7 @@
           "oracleOnly"
         ], 
         "method": "createSubbranch", 
-        "returns": "hash", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "bytes", 
           "int256", 
@@ -1609,7 +1571,6 @@
         ], 
         "method": "createEvent", 
         "returns": "int256", 
-        "send": true, 
         "signature": [
           "int256", 
           "bytes", 
@@ -1633,9 +1594,7 @@
           "extraInfo"
         ], 
         "method": "createMarket", 
-        "mutable": true, 
         "returns": "int256", 
-        "send": true, 
         "signature": [
           "int256", 
           "bytes", 
@@ -1665,9 +1624,7 @@
           "extraInfo"
         ], 
         "method": "createSingleEventMarket", 
-        "mutable": true, 
-        "returns": "hash", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "bytes", 
@@ -1690,8 +1647,7 @@
           "market"
         ], 
         "method": "pushMarketForward", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -1704,8 +1660,7 @@
           "tradingFee"
         ], 
         "method": "updateTradingFee", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -1829,7 +1784,7 @@
           "event"
         ], 
         "method": "getEventBranch", 
-        "returns": "hash", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -1839,7 +1794,7 @@
           "event"
         ], 
         "method": "getEventInfo", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -1869,7 +1824,7 @@
           "event"
         ], 
         "method": "getExpiration", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -1931,7 +1886,7 @@
           "event"
         ], 
         "method": "getMarkets", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -1941,7 +1896,7 @@
           "event"
         ], 
         "method": "getMaxValue", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -1951,7 +1906,7 @@
           "event"
         ], 
         "method": "getMinValue", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -1971,7 +1926,7 @@
           "event"
         ], 
         "method": "getNumOutcomes", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -1991,7 +1946,7 @@
           "event"
         ], 
         "method": "getOutcome", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -2031,7 +1986,7 @@
           "event"
         ], 
         "method": "getReportingThreshold", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -2051,7 +2006,7 @@
           "event"
         ], 
         "method": "getUncaughtOutcome", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -2061,7 +2016,7 @@
           "event"
         ], 
         "method": "getmode", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -2210,8 +2165,7 @@
           "outcome"
         ], 
         "method": "setOutcome", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -2276,7 +2230,6 @@
         ], 
         "method": "addEvent", 
         "returns": "int256", 
-        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -2391,7 +2344,7 @@
           "sender"
         ], 
         "method": "getAfterRep", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -2405,7 +2358,7 @@
           "sender"
         ], 
         "method": "getBeforeRep", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -2459,7 +2412,7 @@
           "eventIndex"
         ], 
         "method": "getEvent", 
-        "returns": "hash", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -2472,7 +2425,7 @@
           "eventID"
         ], 
         "method": "getEventIndex", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -2484,7 +2437,7 @@
           "expDateIndex"
         ], 
         "method": "getEvents", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256", 
           "int256"
@@ -2513,7 +2466,7 @@
           "event"
         ], 
         "method": "getLesserReportNum", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -2602,7 +2555,7 @@
           "expDateIndex"
         ], 
         "method": "getNumberEvents", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -2629,7 +2582,7 @@
           "sender"
         ], 
         "method": "getPeriodRepConstant", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -2658,7 +2611,7 @@
           "sender"
         ], 
         "method": "getReport", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3020,8 +2973,7 @@
     "Faucets": {
       "cashFaucet": {
         "method": "cashFaucet", 
-        "returns": "number", 
-        "send": true
+        "returns": "int256"
       }, 
       "claimInitialRep": {
         "inputs": [
@@ -3040,8 +2992,7 @@
           "branch"
         ], 
         "method": "fundNewAccount", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3051,8 +3002,7 @@
           "branch"
         ], 
         "method": "reputationFaucet", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3190,7 +3140,7 @@
           "ID"
         ], 
         "method": "getCreationFee", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3200,7 +3150,7 @@
           "ID"
         ], 
         "method": "getCreator", 
-        "returns": "address", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3233,8 +3183,7 @@
           "fee"
         ], 
         "method": "setInfo", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "bytes", 
@@ -3252,7 +3201,7 @@
           "sender"
         ], 
         "method": "makeHash", 
-        "returns": "hash", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3268,9 +3217,6 @@
           "ethics"
         ], 
         "method": "submitReport", 
-        "mutable": true, 
-        "returns": "number", 
-        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -3285,8 +3231,7 @@
           "encryptedSaltyHash"
         ], 
         "method": "submitReportHash", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3305,7 +3250,7 @@
           "balance"
         ], 
         "method": "validateReport", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3372,7 +3317,7 @@
           "market"
         ], 
         "method": "getBranchID", 
-        "returns": "hash", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3382,7 +3327,7 @@
           "market"
         ], 
         "method": "getCreationTime", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3392,7 +3337,7 @@
           "market"
         ], 
         "method": "getCumScale", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3412,7 +3357,7 @@
           "market"
         ], 
         "method": "getFees", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3422,7 +3367,7 @@
           "market"
         ], 
         "method": "getLastExpDate", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3454,7 +3399,7 @@
           "market"
         ], 
         "method": "getMakerFees", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3476,7 +3421,7 @@
           "market"
         ], 
         "method": "getMarketEvents", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -3486,7 +3431,7 @@
           "market"
         ], 
         "method": "getMarketNumOutcomes", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3506,7 +3451,7 @@
           "market"
         ], 
         "method": "getNumEvents", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3540,7 +3485,7 @@
           "outcome"
         ], 
         "method": "getParticipantSharesPurchased", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3567,7 +3512,7 @@
           "outcome"
         ], 
         "method": "getSharesPurchased", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -3578,7 +3523,7 @@
           "market"
         ], 
         "method": "getSharesValue", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3598,7 +3543,7 @@
           "market"
         ], 
         "method": "getTradingFee", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3608,7 +3553,7 @@
           "market"
         ], 
         "method": "getTradingPeriod", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3618,7 +3563,7 @@
           "market"
         ], 
         "method": "getVolume", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3628,7 +3573,7 @@
           "market"
         ], 
         "method": "getWinningOutcomes", 
-        "returns": "number[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -3638,7 +3583,7 @@
           "market_id"
         ], 
         "method": "get_total_trades", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3648,7 +3593,7 @@
           "market_id"
         ], 
         "method": "get_trade_ids", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -3658,7 +3603,7 @@
           "market"
         ], 
         "method": "getgasSubsidy", 
-        "returns": "int", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -3726,8 +3671,7 @@
           "amount"
         ], 
         "method": "modifyShares", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3775,7 +3719,7 @@
           "market"
         ], 
         "method": "returnTags", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -3852,8 +3796,7 @@
           "sender"
         ], 
         "method": "penalizationCatchup", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -3868,8 +3811,7 @@
           "eventExample"
         ], 
         "method": "proveReporterDidntReportEnough", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3897,8 +3839,7 @@
           "value"
         ], 
         "method": "addDormantRep", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3912,8 +3853,7 @@
           "value"
         ], 
         "method": "addRep", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3929,8 +3869,7 @@
           "repToBonderOrBranch"
         ], 
         "method": "addReporter", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -3945,8 +3884,7 @@
           "amount"
         ], 
         "method": "adjustActiveRep", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -3958,7 +3896,7 @@
           "address"
         ], 
         "method": "balanceOf", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -3991,7 +3929,7 @@
           "branch"
         ], 
         "method": "getActiveRep", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4002,7 +3940,7 @@
           "repIndex"
         ], 
         "method": "getDormantRepByIndex", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4013,7 +3951,7 @@
           "branch"
         ], 
         "method": "getFork", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4023,7 +3961,7 @@
           "branch"
         ], 
         "method": "getNumberReporters", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4034,7 +3972,7 @@
           "address"
         ], 
         "method": "getRepBalance", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4046,7 +3984,7 @@
           "repIndex"
         ], 
         "method": "getRepByIndex", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4058,7 +3996,7 @@
           "index"
         ], 
         "method": "getReporterID", 
-        "returns": "hash", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4069,7 +4007,7 @@
           "address"
         ], 
         "method": "getReputation", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -4079,7 +4017,7 @@
           "branch"
         ], 
         "method": "getTotalRep", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4090,7 +4028,7 @@
           "repID"
         ], 
         "method": "repIDToIndex", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4101,8 +4039,7 @@
           "branch"
         ], 
         "method": "setFork", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4113,8 +4050,7 @@
           "branchID"
         ], 
         "method": "setInitialReporters", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4127,8 +4063,7 @@
           "newRep"
         ], 
         "method": "setRep", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4142,8 +4077,7 @@
           "branchID"
         ], 
         "method": "setSaleDistribution", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256[]", 
           "int256[]", 
@@ -4157,7 +4091,6 @@
         ], 
         "method": "setWhitelist", 
         "returns": "string", 
-        "send": true, 
         "signature": [
           "int256", 
           "int256[]"
@@ -4170,8 +4103,7 @@
           "value"
         ], 
         "method": "subtractDormantRep", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4185,8 +4117,7 @@
           "value"
         ], 
         "method": "subtractRep", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4198,7 +4129,7 @@
           "branch"
         ], 
         "method": "totalSupply", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4287,8 +4218,7 @@
           "event"
         ], 
         "method": "resolve", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4302,8 +4232,7 @@
           "votePeriod"
         ], 
         "method": "roundTwoPostBond", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4319,8 +4248,7 @@
           "sender"
         ], 
         "method": "roundTwoResolve", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4401,8 +4329,7 @@
           "value"
         ], 
         "method": "sendReputation", 
-        "returns": "unfix", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4450,8 +4377,7 @@
           "eventID"
         ], 
         "method": "slashRep", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4468,9 +4394,6 @@
           "max_amount"
         ], 
         "method": "short_sell", 
-        "mutable": true, 
-        "returns": "hash[]", 
-        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -4483,9 +4406,6 @@
           "trade_ids"
         ], 
         "method": "trade", 
-        "mutable": true, 
-        "returns": "hash[]", 
-        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4500,7 +4420,7 @@
           "sender"
         ], 
         "method": "checkHash", 
-        "returns": "number", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4511,8 +4431,7 @@
           "hash"
         ], 
         "method": "commitTrade", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4523,8 +4442,7 @@
           "fill"
         ], 
         "method": "fill_trade", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256"
@@ -4535,7 +4453,7 @@
           "tradeID"
         ], 
         "method": "getID", 
-        "returns": "hash", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4545,7 +4463,7 @@
           "id"
         ], 
         "method": "get_amount", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4555,7 +4473,7 @@
           "id"
         ], 
         "method": "get_price", 
-        "returns": "unfix", 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4565,7 +4483,7 @@
           "id"
         ], 
         "method": "get_trade", 
-        "returns": "hash[]", 
+        "returns": "int256[]", 
         "signature": [
           "int256"
         ]
@@ -4577,7 +4495,7 @@
           "trade_ids"
         ], 
         "method": "makeTradeHash", 
-        "returns": "hash", 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4589,8 +4507,7 @@
           "id"
         ], 
         "method": "remove_trade", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256"
         ]
@@ -4606,8 +4523,7 @@
           "outcome"
         ], 
         "method": "saveTrade", 
-        "returns": "number", 
-        "send": true, 
+        "returns": "int256", 
         "signature": [
           "int256", 
           "int256", 
@@ -4624,7 +4540,6 @@
           "price"
         ], 
         "method": "update_trade", 
-        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -4632,8 +4547,7 @@
       }, 
       "zeroHash": {
         "method": "zeroHash", 
-        "returns": "number", 
-        "send": true
+        "returns": "int256"
       }
     }
   }

--- a/api.json
+++ b/api.json
@@ -346,7 +346,7 @@
           "event"
         ], 
         "method": "getBondPoster", 
-        "returns": "int256", 
+        "returns": "address", 
         "signature": [
           "int256"
         ]
@@ -446,7 +446,7 @@
           "event"
         ], 
         "method": "getOriginalVotePeriod", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -503,7 +503,8 @@
           "bondPoster"
         ], 
         "method": "setBondPoster", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -524,7 +525,8 @@
           "event"
         ], 
         "method": "setFinal", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -579,7 +581,8 @@
           "ethicality"
         ], 
         "method": "setOriginalEthicality", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -591,7 +594,8 @@
           "originalOutcome"
         ], 
         "method": "setOriginalOutcome", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -603,7 +607,8 @@
           "period"
         ], 
         "method": "setOriginalVotePeriod", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -629,7 +634,8 @@
           "roundTwo"
         ], 
         "method": "setRoundTwo", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -676,14 +682,14 @@
           "branchNumber"
         ], 
         "method": "getBranchByNum", 
-        "returns": "int256", 
+        "returns": "hash", 
         "signature": [
           "int256"
         ]
       }, 
       "getBranches": {
         "method": "getBranches", 
-        "returns": "int256[]"
+        "returns": "hash[]"
       }, 
       "getCreationDate": {
         "inputs": [
@@ -732,7 +738,7 @@
           "branch"
         ], 
         "method": "getMarketsInBranch", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -742,21 +748,21 @@
           "branch"
         ], 
         "method": "getMinTradingFee", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
       }, 
       "getNumBranches": {
         "method": "getNumBranches", 
-        "returns": "int256"
+        "returns": "number"
       }, 
       "getNumMarketsBranch": {
         "inputs": [
           "branch"
         ], 
         "method": "getNumMarketsBranch", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -796,7 +802,7 @@
           "branch"
         ], 
         "method": "getPeriodLength", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -820,7 +826,7 @@
           "branch"
         ], 
         "method": "getVotePeriod", 
-        "returns": "int256", 
+        "returns": "int", 
         "signature": [
           "int256"
         ]
@@ -830,14 +836,16 @@
           "branch"
         ], 
         "method": "incrementPeriod", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
       }, 
       "initDefaultBranch": {
         "method": "initDefaultBranch", 
-        "returns": "int256"
+        "returns": "number", 
+        "send": true
       }, 
       "initializeBranch": {
         "inputs": [
@@ -919,7 +927,8 @@
           "outcome"
         ], 
         "method": "buy", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -932,7 +941,8 @@
           "trade_id"
         ], 
         "method": "cancel", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -945,7 +955,8 @@
           "outcome"
         ], 
         "method": "sell", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -961,7 +972,8 @@
           "amount"
         ], 
         "method": "addCash", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -972,21 +984,23 @@
           "address"
         ], 
         "method": "balance", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
       }, 
       "depositEther": {
         "method": "depositEther", 
-        "returns": "int256"
+        "returns": "number", 
+        "send": true
       }, 
       "initiateOwner": {
         "inputs": [
           "account"
         ], 
         "method": "initiateOwner", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -997,7 +1011,8 @@
           "value"
         ], 
         "method": "send", 
-        "returns": "int256", 
+        "returns": "unfix", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1010,7 +1025,8 @@
           "from"
         ], 
         "method": "sendFrom", 
-        "returns": "int256", 
+        "returns": "unfix", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -1023,7 +1039,8 @@
           "balance"
         ], 
         "method": "setCash", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1047,7 +1064,8 @@
           "value"
         ], 
         "method": "withdrawEther", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1061,7 +1079,8 @@
           "market"
         ], 
         "method": "claimProceeds", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1074,7 +1093,8 @@
           "sender"
         ], 
         "method": "closeMarket", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -1127,7 +1147,8 @@
           "sender"
         ], 
         "method": "collectFees", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1141,7 +1162,8 @@
           "amount"
         ], 
         "method": "buyCompleteSets", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1153,7 +1175,8 @@
           "amount"
         ], 
         "method": "sellCompleteSets", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1166,7 +1189,7 @@
           "marketIDs"
         ], 
         "method": "batchGetMarketInfo", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256[]"
         ]
@@ -1176,7 +1199,7 @@
           "marketID"
         ], 
         "method": "getMarketInfo", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -1188,7 +1211,7 @@
           "numMarketsToLoad"
         ], 
         "method": "getMarketsInfo", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256", 
           "int256", 
@@ -1200,7 +1223,7 @@
           "marketID"
         ], 
         "method": "getOrderBook", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -1212,7 +1235,8 @@
           "branch"
         ], 
         "method": "incrementPeriodAfterReporting", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -1223,6 +1247,9 @@
           "event"
         ], 
         "method": "penalizeWrong", 
+        "mutable": true, 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1283,7 +1310,7 @@
           "period"
         ], 
         "method": "getFeesCollected", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256", 
           "int256", 
@@ -1340,7 +1367,7 @@
           "sender"
         ], 
         "method": "getPenalizedUpTo", 
-        "returns": "int256", 
+        "returns": "int", 
         "signature": [
           "int256", 
           "int256"
@@ -1364,7 +1391,7 @@
           "reporter"
         ], 
         "method": "getRepRedistributionDone", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256", 
           "int256"
@@ -1548,7 +1575,8 @@
           "oracleOnly"
         ], 
         "method": "createSubbranch", 
-        "returns": "int256", 
+        "returns": "hash", 
+        "send": true, 
         "signature": [
           "bytes", 
           "int256", 
@@ -1571,6 +1599,7 @@
         ], 
         "method": "createEvent", 
         "returns": "int256", 
+        "send": true, 
         "signature": [
           "int256", 
           "bytes", 
@@ -1594,7 +1623,9 @@
           "extraInfo"
         ], 
         "method": "createMarket", 
+        "mutable": true, 
         "returns": "int256", 
+        "send": true, 
         "signature": [
           "int256", 
           "bytes", 
@@ -1624,7 +1655,9 @@
           "extraInfo"
         ], 
         "method": "createSingleEventMarket", 
-        "returns": "int256", 
+        "mutable": true, 
+        "returns": "hash", 
+        "send": true, 
         "signature": [
           "int256", 
           "bytes", 
@@ -1647,7 +1680,8 @@
           "market"
         ], 
         "method": "pushMarketForward", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -1660,7 +1694,8 @@
           "tradingFee"
         ], 
         "method": "updateTradingFee", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -1784,7 +1819,7 @@
           "event"
         ], 
         "method": "getEventBranch", 
-        "returns": "int256", 
+        "returns": "hash", 
         "signature": [
           "int256"
         ]
@@ -1794,7 +1829,7 @@
           "event"
         ], 
         "method": "getEventInfo", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -1824,7 +1859,7 @@
           "event"
         ], 
         "method": "getExpiration", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -1886,7 +1921,7 @@
           "event"
         ], 
         "method": "getMarkets", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -1896,7 +1931,7 @@
           "event"
         ], 
         "method": "getMaxValue", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -1906,7 +1941,7 @@
           "event"
         ], 
         "method": "getMinValue", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -1926,7 +1961,7 @@
           "event"
         ], 
         "method": "getNumOutcomes", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -1946,7 +1981,7 @@
           "event"
         ], 
         "method": "getOutcome", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -1986,7 +2021,7 @@
           "event"
         ], 
         "method": "getReportingThreshold", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -2006,7 +2041,7 @@
           "event"
         ], 
         "method": "getUncaughtOutcome", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -2016,7 +2051,7 @@
           "event"
         ], 
         "method": "getmode", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -2165,7 +2200,8 @@
           "outcome"
         ], 
         "method": "setOutcome", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -2230,6 +2266,7 @@
         ], 
         "method": "addEvent", 
         "returns": "int256", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -2344,7 +2381,7 @@
           "sender"
         ], 
         "method": "getAfterRep", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256", 
@@ -2358,7 +2395,7 @@
           "sender"
         ], 
         "method": "getBeforeRep", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256", 
@@ -2412,7 +2449,7 @@
           "eventIndex"
         ], 
         "method": "getEvent", 
-        "returns": "int256", 
+        "returns": "hash", 
         "signature": [
           "int256", 
           "int256", 
@@ -2425,7 +2462,7 @@
           "eventID"
         ], 
         "method": "getEventIndex", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256", 
           "int256"
@@ -2437,7 +2474,7 @@
           "expDateIndex"
         ], 
         "method": "getEvents", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256", 
           "int256"
@@ -2466,7 +2503,7 @@
           "event"
         ], 
         "method": "getLesserReportNum", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256", 
@@ -2555,7 +2592,7 @@
           "expDateIndex"
         ], 
         "method": "getNumberEvents", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256", 
           "int256"
@@ -2582,7 +2619,7 @@
           "sender"
         ], 
         "method": "getPeriodRepConstant", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256", 
@@ -2611,7 +2648,7 @@
           "sender"
         ], 
         "method": "getReport", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256", 
@@ -2973,7 +3010,8 @@
     "Faucets": {
       "cashFaucet": {
         "method": "cashFaucet", 
-        "returns": "int256"
+        "returns": "number", 
+        "send": true
       }, 
       "claimInitialRep": {
         "inputs": [
@@ -2992,7 +3030,8 @@
           "branch"
         ], 
         "method": "fundNewAccount", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -3002,7 +3041,8 @@
           "branch"
         ], 
         "method": "reputationFaucet", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -3140,7 +3180,7 @@
           "ID"
         ], 
         "method": "getCreationFee", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -3150,7 +3190,7 @@
           "ID"
         ], 
         "method": "getCreator", 
-        "returns": "int256", 
+        "returns": "address", 
         "signature": [
           "int256"
         ]
@@ -3183,7 +3223,8 @@
           "fee"
         ], 
         "method": "setInfo", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "bytes", 
@@ -3201,7 +3242,7 @@
           "sender"
         ], 
         "method": "makeHash", 
-        "returns": "int256", 
+        "returns": "hash", 
         "signature": [
           "int256", 
           "int256", 
@@ -3217,6 +3258,9 @@
           "ethics"
         ], 
         "method": "submitReport", 
+        "mutable": true, 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -3231,7 +3275,8 @@
           "encryptedSaltyHash"
         ], 
         "method": "submitReportHash", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -3250,7 +3295,7 @@
           "balance"
         ], 
         "method": "validateReport", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256", 
           "int256", 
@@ -3317,7 +3362,7 @@
           "market"
         ], 
         "method": "getBranchID", 
-        "returns": "int256", 
+        "returns": "hash", 
         "signature": [
           "int256"
         ]
@@ -3327,7 +3372,7 @@
           "market"
         ], 
         "method": "getCreationTime", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -3337,7 +3382,7 @@
           "market"
         ], 
         "method": "getCumScale", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -3357,7 +3402,7 @@
           "market"
         ], 
         "method": "getFees", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -3367,7 +3412,7 @@
           "market"
         ], 
         "method": "getLastExpDate", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -3399,7 +3444,7 @@
           "market"
         ], 
         "method": "getMakerFees", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -3421,7 +3466,7 @@
           "market"
         ], 
         "method": "getMarketEvents", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -3431,7 +3476,7 @@
           "market"
         ], 
         "method": "getMarketNumOutcomes", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -3451,7 +3496,7 @@
           "market"
         ], 
         "method": "getNumEvents", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -3485,7 +3530,7 @@
           "outcome"
         ], 
         "method": "getParticipantSharesPurchased", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256", 
@@ -3512,7 +3557,7 @@
           "outcome"
         ], 
         "method": "getSharesPurchased", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256"
@@ -3523,7 +3568,7 @@
           "market"
         ], 
         "method": "getSharesValue", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -3543,7 +3588,7 @@
           "market"
         ], 
         "method": "getTradingFee", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -3553,7 +3598,7 @@
           "market"
         ], 
         "method": "getTradingPeriod", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -3563,7 +3608,7 @@
           "market"
         ], 
         "method": "getVolume", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -3573,7 +3618,7 @@
           "market"
         ], 
         "method": "getWinningOutcomes", 
-        "returns": "int256[]", 
+        "returns": "number[]", 
         "signature": [
           "int256"
         ]
@@ -3583,7 +3628,7 @@
           "market_id"
         ], 
         "method": "get_total_trades", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -3593,7 +3638,7 @@
           "market_id"
         ], 
         "method": "get_trade_ids", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -3603,7 +3648,7 @@
           "market"
         ], 
         "method": "getgasSubsidy", 
-        "returns": "int256", 
+        "returns": "int", 
         "signature": [
           "int256"
         ]
@@ -3671,7 +3716,8 @@
           "amount"
         ], 
         "method": "modifyShares", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -3719,7 +3765,7 @@
           "market"
         ], 
         "method": "returnTags", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -3796,7 +3842,8 @@
           "sender"
         ], 
         "method": "penalizationCatchup", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -3811,7 +3858,8 @@
           "eventExample"
         ], 
         "method": "proveReporterDidntReportEnough", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -3839,7 +3887,8 @@
           "value"
         ], 
         "method": "addDormantRep", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -3853,7 +3902,8 @@
           "value"
         ], 
         "method": "addRep", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -3869,7 +3919,8 @@
           "repToBonderOrBranch"
         ], 
         "method": "addReporter", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -3884,7 +3935,8 @@
           "amount"
         ], 
         "method": "adjustActiveRep", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -3896,7 +3948,7 @@
           "address"
         ], 
         "method": "balanceOf", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256"
@@ -3929,7 +3981,7 @@
           "branch"
         ], 
         "method": "getActiveRep", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -3940,7 +3992,7 @@
           "repIndex"
         ], 
         "method": "getDormantRepByIndex", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256"
@@ -3951,7 +4003,7 @@
           "branch"
         ], 
         "method": "getFork", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -3961,7 +4013,7 @@
           "branch"
         ], 
         "method": "getNumberReporters", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256"
         ]
@@ -3972,7 +4024,7 @@
           "address"
         ], 
         "method": "getRepBalance", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256"
@@ -3984,7 +4036,7 @@
           "repIndex"
         ], 
         "method": "getRepByIndex", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256", 
           "int256"
@@ -3996,7 +4048,7 @@
           "index"
         ], 
         "method": "getReporterID", 
-        "returns": "int256", 
+        "returns": "hash", 
         "signature": [
           "int256", 
           "int256"
@@ -4007,7 +4059,7 @@
           "address"
         ], 
         "method": "getReputation", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -4017,7 +4069,7 @@
           "branch"
         ], 
         "method": "getTotalRep", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -4028,7 +4080,7 @@
           "repID"
         ], 
         "method": "repIDToIndex", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256", 
           "int256"
@@ -4039,7 +4091,8 @@
           "branch"
         ], 
         "method": "setFork", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -4050,7 +4103,8 @@
           "branchID"
         ], 
         "method": "setInitialReporters", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -4063,7 +4117,8 @@
           "newRep"
         ], 
         "method": "setRep", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4077,7 +4132,8 @@
           "branchID"
         ], 
         "method": "setSaleDistribution", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256[]", 
           "int256[]", 
@@ -4091,6 +4147,7 @@
         ], 
         "method": "setWhitelist", 
         "returns": "string", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256[]"
@@ -4103,7 +4160,8 @@
           "value"
         ], 
         "method": "subtractDormantRep", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4117,7 +4175,8 @@
           "value"
         ], 
         "method": "subtractRep", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4129,7 +4188,7 @@
           "branch"
         ], 
         "method": "totalSupply", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -4218,7 +4277,8 @@
           "event"
         ], 
         "method": "resolve", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -4232,7 +4292,8 @@
           "votePeriod"
         ], 
         "method": "roundTwoPostBond", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4248,7 +4309,8 @@
           "sender"
         ], 
         "method": "roundTwoResolve", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4329,7 +4391,8 @@
           "value"
         ], 
         "method": "sendReputation", 
-        "returns": "int256", 
+        "returns": "unfix", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4377,7 +4440,8 @@
           "eventID"
         ], 
         "method": "slashRep", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4394,6 +4458,9 @@
           "max_amount"
         ], 
         "method": "short_sell", 
+        "mutable": true, 
+        "returns": "hash[]", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -4406,6 +4473,9 @@
           "trade_ids"
         ], 
         "method": "trade", 
+        "mutable": true, 
+        "returns": "hash[]", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4420,7 +4490,7 @@
           "sender"
         ], 
         "method": "checkHash", 
-        "returns": "int256", 
+        "returns": "number", 
         "signature": [
           "int256", 
           "int256"
@@ -4431,7 +4501,8 @@
           "hash"
         ], 
         "method": "commitTrade", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -4442,7 +4513,8 @@
           "fill"
         ], 
         "method": "fill_trade", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -4453,7 +4525,7 @@
           "tradeID"
         ], 
         "method": "getID", 
-        "returns": "int256", 
+        "returns": "hash", 
         "signature": [
           "int256"
         ]
@@ -4463,7 +4535,7 @@
           "id"
         ], 
         "method": "get_amount", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -4473,7 +4545,7 @@
           "id"
         ], 
         "method": "get_price", 
-        "returns": "int256", 
+        "returns": "unfix", 
         "signature": [
           "int256"
         ]
@@ -4483,7 +4555,7 @@
           "id"
         ], 
         "method": "get_trade", 
-        "returns": "int256[]", 
+        "returns": "hash[]", 
         "signature": [
           "int256"
         ]
@@ -4495,7 +4567,7 @@
           "trade_ids"
         ], 
         "method": "makeTradeHash", 
-        "returns": "int256", 
+        "returns": "hash", 
         "signature": [
           "int256", 
           "int256", 
@@ -4507,7 +4579,8 @@
           "id"
         ], 
         "method": "remove_trade", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256"
         ]
@@ -4523,7 +4596,8 @@
           "outcome"
         ], 
         "method": "saveTrade", 
-        "returns": "int256", 
+        "returns": "number", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256", 
@@ -4540,6 +4614,7 @@
           "price"
         ], 
         "method": "update_trade", 
+        "send": true, 
         "signature": [
           "int256", 
           "int256"
@@ -4547,7 +4622,8 @@
       }, 
       "zeroHash": {
         "method": "zeroHash", 
-        "returns": "int256"
+        "returns": "number", 
+        "send": true
       }
     }
   }

--- a/contracts.json
+++ b/contracts.json
@@ -46,7 +46,7 @@
         "CloseMarketTwo": "0xee856109cd107e5521b86374dd53c8b2120ab14f", 
         "CollectFees": "0xa5f4f3b326e1719b9ece4058aceaf771a483d012", 
         "CompleteSets": "0x5485af8bf299235b7fd2e45f13be79cf6064df64", 
-        "CompositeGetters": "0xcd49a9bf994b9cc61a3af5cf70588d9eedd1acc3", 
+        "CompositeGetters": "0xc5318e0ae3ef2f6883d12f88ac16896074f22c0d", 
         "Consensus": "0xd75138a01cc0d56d6bfc4e00088458e501657579", 
         "ConsensusData": "0x9011169bf11bc061fdaaf42ec919c81df5b95210", 
         "CreateBranch": "0xbcfa90799eaf78ea417b94bb62ff2a4373689d6a", 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-contracts",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Augur contract addresses, transactions, and error codes",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I removed getMarketInfoCache since it's no longer needed: https://github.com/AugurProject/augur-core/pull/92

@tinybike has there been a change to make_api.py recently. Running it after I updated the latest compositeGetters changed much more than I expected in api.json.
