### PR TITLE
Make update-contracts.sh safer

### DIFF
--- a/update-contracts.sh
+++ b/update-contracts.sh
@@ -1,30 +1,51 @@
 #!/bin/bash
 
+# extended pattern matching
+shopt -s extglob
+
+if [[ "${SOURCE}x" == "x" ]]; then
+  echo "SOURCE environment variable required with path to augur-core/output/contracts"
+  exit 1
+fi
+
 npx dotsunited-merge-json addresses.json $SOURCE/addresses.json | npx jq.node --color=false --json > ./updated.json
+[[ $? == 0 ]] || exit $?
+
 mv updated.json addresses.json
 
 cat $SOURCE/contracts.json | npx jqn --color=false -j "at('contracts') | map(values) | flatten | map(mapValues(get('abi'))) | reduce(merge, {})" > ./abi.json
+[[ $? == 0 ]] || exit $?
 
-if [[ "$SKIP_COMMIT" == "true" ]]; then
-  echo "Files updated, commit and push manually"
-else
+if [[ "$AUTOCOMMIT" == "true" ]]; then
   git add addresses.json abi.json
   git commit -m "Auto-updating from push to augur-core#${BRANCH} (${COMMIT})"
 
   case $BRANCH in
-    "master")
+    v+([:digit:]).+([:digit:]).+([:digit:]))
+      if [[ "$BRANCH" == "$TAG" ]]; then
+        # Commit on a tag, this will do all the work of commiting and pushing
+        # a new release
+        echo "Update master of augur-contracts, and publishning new NPM version"
+        git version patch
+        git tag augur-core-$TAG # create a tag to match the augur-core tag
+        git push && push --tags && npm publish
+      fi
+      ;;
+    master)
       echo "Update master of augur-contracts, manual NPM release needed"
       git push
       ;;
-    "develop")
+    develop)
       echo "Updating develop branch of augur-contracts with force push"
       git checkout -b $BRANCH origin/$BRANCH
       git push --force-with-lease
       ;;
     *)
-      echo "Making new branch on augur-contracts to match ${BRANCH}"
-      git checkout -b core_branch_$BRANCH
-      git push origin core_branch_$BRANCH --force-with-lease
+      echo "Making new branch (augur-core/${BRANCH} on augur-contracts to match ${BRANCH}"
+      git checkout -b augur-core/$BRANCH
+      git push origin augur-core/$BRANCH --force-with-lease
       ;;
   esac
+else
+  echo "Files updated, commit and push manually"
 fi

--- a/update-contracts.sh
+++ b/update-contracts.sh
@@ -26,7 +26,7 @@ if [[ "$AUTOCOMMIT" == "true" ]]; then
         # Commit on a tag, this will do all the work of commiting and pushing
         # a new release
         echo "Update master of augur-contracts, and publishning new NPM version"
-        git version patch
+        npm version patch
         git tag augur-core-$TAG # create a tag to match the augur-core tag
         #git push && push --tags && npm publish
       fi

--- a/update-contracts.sh
+++ b/update-contracts.sh
@@ -27,7 +27,7 @@ if [[ "$AUTOCOMMIT" == "true" ]]; then
         # a new release
         echo "Update master of augur-contracts, and publishning new NPM version"
         npm version patch
-        git tag augur-core-$TAG # create a tag to match the augur-core tag
+        git tag augur-core/$TAG # create a tag to match the augur-core tag
         #git push && push --tags && npm publish
       fi
       ;;

--- a/update-contracts.sh
+++ b/update-contracts.sh
@@ -21,7 +21,7 @@ if [[ "$AUTOCOMMIT" == "true" ]]; then
   git commit -m "Auto-updating from push to augur-core#${BRANCH} (${COMMIT})"
 
   case $BRANCH in
-    v+([:digit:]).+([:digit:]).+([:digit:]))
+    v+([0-9]).+([0-9]).+([0-9]))
       if [[ "$BRANCH" == "$TAG" ]]; then
         # Commit on a tag, this will do all the work of commiting and pushing
         # a new release

--- a/update-contracts.sh
+++ b/update-contracts.sh
@@ -9,12 +9,12 @@ if [[ "${SOURCE}x" == "x" ]]; then
 fi
 
 npx dotsunited-merge-json addresses.json $SOURCE/addresses.json | npx jq.node --color=false --json > ./updated.json
-[[ $? == 0 ]] || exit $?
+[[ $? == 0 ]] || exit 1
 
 mv updated.json addresses.json
 
 cat $SOURCE/contracts.json | npx jqn --color=false -j "at('contracts') | map(values) | flatten | map(mapValues(get('abi'))) | reduce(merge, {})" > ./abi.json
-[[ $? == 0 ]] || exit $?
+[[ $? == 0 ]] || exit 1
 
 if [[ "$AUTOCOMMIT" == "true" ]]; then
   git add addresses.json abi.json
@@ -28,22 +28,22 @@ if [[ "$AUTOCOMMIT" == "true" ]]; then
         echo "Update master of augur-contracts, and publishning new NPM version"
         npm version patch
         git tag augur-core/$TAG # create a tag to match the augur-core tag
-        #git push && push --tags && npm publish
+        git push && push --tags && npm publish
       fi
       ;;
     master)
       echo "Update master of augur-contracts, manual NPM release needed"
-      #git push
+      git push
       ;;
     develop)
       echo "Updating develop branch of augur-contracts with force push"
       git checkout -b $BRANCH origin/$BRANCH
-      #git push --force-with-lease
+      git push --force-with-lease
       ;;
     *)
       echo "Making new branch (augur-core/${BRANCH} on augur-contracts to match ${BRANCH}"
       git checkout -b augur-core/$BRANCH
-      #git push origin augur-core/$BRANCH --force-with-lease
+      git push origin augur-core/$BRANCH --force-with-lease
       ;;
   esac
 else

--- a/update-contracts.sh
+++ b/update-contracts.sh
@@ -28,22 +28,22 @@ if [[ "$AUTOCOMMIT" == "true" ]]; then
         echo "Update master of augur-contracts, and publishning new NPM version"
         git version patch
         git tag augur-core-$TAG # create a tag to match the augur-core tag
-        git push && push --tags && npm publish
+        #git push && push --tags && npm publish
       fi
       ;;
     master)
       echo "Update master of augur-contracts, manual NPM release needed"
-      git push
+      #git push
       ;;
     develop)
       echo "Updating develop branch of augur-contracts with force push"
       git checkout -b $BRANCH origin/$BRANCH
-      git push --force-with-lease
+      #git push --force-with-lease
       ;;
     *)
       echo "Making new branch (augur-core/${BRANCH} on augur-contracts to match ${BRANCH}"
       git checkout -b augur-core/$BRANCH
-      git push origin augur-core/$BRANCH --force-with-lease
+      #git push origin augur-core/$BRANCH --force-with-lease
       ;;
   esac
 else


### PR DESCRIPTION
This switches to non-auto-commit mode by default so someone can play around with the settings to make the build they want before auto pushing. These changes match up to augur-contracts#paul and we will merge both at the same time.